### PR TITLE
Publish to local Maven repo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '7.0.0'
     id 'com.github.sherter.google-java-format' version '0.9'
     id 'com.intershop.gradle.javacc' version '4.0.1'
+    id 'maven-publish'
 }
 
 group 'silverchain'
@@ -82,4 +83,14 @@ task testGeneratedJava(type: Exec) {
 
 check {
     dependsOn testGeneratedJava
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            groupId = 'com.github.tomokinakamaru.silverchain'
+
+            from components.java
+        }
+    }
 }


### PR DESCRIPTION
Publishing to the local Maven repository allows Maven-based projects to declare a dependency to Silverchain. I want to use this to create a Maven plugin for Silverchain so that one doesn't need to use Docker.

(Note that in order to publish those other projects to Maven Central, Silverchain would need to be available there as well. But that's a different story for which I'll open an issue.)