### PR TITLE
Add Maven info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,33 @@ See [here](https://github.com/tomokinakamaru/silverchain/blob/main/doc/tutorial.
 docker run -v $(pwd):/workdir --rm -it tomokinakamaru/silverchain:latest
 ```
 
+
+## Run with Maven
+
+[![Maven Central](https://img.shields.io/maven-metadata/v.svg?color=informational&label=silverchain-maven-plugin%20%E2%99%A6%20latest&metadataUrl=https%3A%2F%2Frepo1.maven.org%2Fmaven2%2Fcom%2Fgithub%2Fbannmann%2Fmaven%2Fsilverchain%2Fsilverchain-maven-plugin%2Fmaven-metadata.xml)](https://maven-badges.herokuapp.com/maven-central/com.github.bannmann.maven.silverchain/silverchain-maven-plugin)
+
+Add the plugin to your `pom.xml` as follows, setting `<version>` and `<inputFile>` as desired.
+
+Output directory and Javadoc source directory are set to the default Maven locations. See the [Mojo source code](https://github.com/bannmann/silverchain-maven-plugin/blob/main/src/main/java/com/github/bannmann/maven/silverchain/GenerateMojo.java) for how to override them.
+
+```xml
+<plugin>
+    <groupId>com.github.bannmann.maven.silverchain</groupId>
+    <artifactId>silverchain-maven-plugin</artifactId>
+    <version>PUT_VERSION_HERE</version>
+    <configuration>
+        <inputFile>src/main/silverchain/my-example-api.ag</inputFile>
+    </configuration>
+    <executions>
+        <execution>
+            <goals>
+                <goal>generate</goal>
+            </goals>
+        </execution>
+    </executions>
+</plugin>
+```
+
 ## Build jar
 
 ```sh


### PR DESCRIPTION
Now that the plugin is available on Maven Central, let's point Silverchain users to it.

Thanks to the included shields.io badge, this will always display the latest plugin release. At the top of the file, I also added a Maven Central badge for Silverchain itself.