### PR TITLE
Fix validation

### DIFF
--- a/src/main/java/silverchain/Cli.java
+++ b/src/main/java/silverchain/Cli.java
@@ -10,7 +10,6 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.IVersionProvider;
 import picocli.CommandLine.Option;
 import silverchain.generator.Generator;
-import silverchain.validator.Validator;
 
 @Command(name = "silverchain", versionProvider = Cli.class, sortOptions = false)
 public final class Cli implements Callable<Integer>, IVersionProvider {

--- a/src/main/java/silverchain/Silverchain.java
+++ b/src/main/java/silverchain/Silverchain.java
@@ -17,8 +17,6 @@ import silverchain.generator.GeneratorProvider;
 import silverchain.javadoc.Javadocs;
 import silverchain.parser.*;
 import silverchain.parser.adapter.Parser;
-import silverchain.validator.Validator;
-import silverchain.validator.ValidatorProvider;
 import silverchain.warning.WarningHandler;
 
 public final class Silverchain {

--- a/src/main/java/silverchain/ValidationError.java
+++ b/src/main/java/silverchain/ValidationError.java
@@ -1,6 +1,4 @@
-package silverchain.validator;
-
-import silverchain.SilverchainException;
+package silverchain;
 
 public final class ValidationError extends SilverchainException {
 

--- a/src/main/java/silverchain/Validator.java
+++ b/src/main/java/silverchain/Validator.java
@@ -1,4 +1,4 @@
-package silverchain.validator;
+package silverchain;
 
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;

--- a/src/main/java/silverchain/ValidatorProvider.java
+++ b/src/main/java/silverchain/ValidatorProvider.java
@@ -1,4 +1,4 @@
-package silverchain.validator;
+package silverchain;
 
 import java.util.function.Function;
 import silverchain.diagram.Diagrams;

--- a/src/main/java/silverchain/validator/Validator.java
+++ b/src/main/java/silverchain/validator/Validator.java
@@ -1,7 +1,5 @@
 package silverchain.validator;
 
-import static java.lang.String.join;
-import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Stream.concat;
@@ -14,11 +12,7 @@ import silverchain.diagram.Diagrams;
 import silverchain.diagram.Label;
 import silverchain.diagram.State;
 import silverchain.diagram.Transition;
-import silverchain.parser.FormalParameter;
-import silverchain.parser.FormalParameters;
-import silverchain.parser.Method;
 import silverchain.parser.Range;
-import silverchain.parser.TypeReference;
 
 public final class Validator {
 
@@ -41,16 +35,7 @@ public final class Validator {
   }
 
   private void validate(State state) {
-    checkTypeReferenceConflict(state);
     checkTypeReferenceMethodConflict(state);
-    checkMethodConflict(state);
-  }
-
-  private void checkTypeReferenceConflict(State state) {
-    List<Label> labels = state.typeReferences();
-    if (1 < labels.size()) {
-      throwError(labels);
-    }
   }
 
   private void checkTypeReferenceMethodConflict(State state) {
@@ -60,14 +45,6 @@ public final class Validator {
       Stream<Label> s1 = labels.stream();
       Stream<Label> s2 = transitions.stream().map(Transition::label);
       throwError(concat(s1, s2).collect(toList()));
-    }
-  }
-
-  private void checkMethodConflict(State state) {
-    for (List<Label> labels : getLabelGroups(state)) {
-      if (1 < labels.size()) {
-        throwError(labels);
-      }
     }
   }
 
@@ -89,37 +66,5 @@ public final class Validator {
 
   private String stringify(Range range) {
     return range.begin().toString();
-  }
-
-  private Collection<List<Label>> getLabelGroups(State state) {
-    return state.transitions().stream()
-        .map(Transition::label)
-        .collect(groupingBy(this::getSignature))
-        .values();
-  }
-
-  private String getSignature(Label label) {
-    return getSignature(label.method());
-  }
-
-  private String getSignature(Method method) {
-    String s = method.parameters().formalParameters().map(this::getSignature).orElse("");
-    return method.name() + ":" + s;
-  }
-
-  private String getSignature(FormalParameters parameters) {
-    return parameters.stream().map(this::getSignature).collect(joining(" "));
-  }
-
-  private String getSignature(FormalParameter parameter) {
-    String s1 = getSignature(parameter.type());
-    String s2 = parameter.isVarArgs() ? "[]" : "";
-    return s1 + s2;
-  }
-
-  private String getSignature(TypeReference reference) {
-    String s1 = reference.referent() == null ? join(".", reference.name()) : "Object";
-    String s2 = reference.isArray() ? "[]" : "";
-    return s1 + s2;
   }
 }

--- a/src/test/java/validator/Tests.java
+++ b/src/test/java/validator/Tests.java
@@ -4,7 +4,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
-import silverchain.validator.ValidationError;
+import silverchain.ValidationError;
 
 final class Tests {
 

--- a/src/test/java/validator/Tests.java
+++ b/src/test/java/validator/Tests.java
@@ -9,18 +9,8 @@ import silverchain.validator.ValidationError;
 final class Tests {
 
   @Test
-  void testJavaTypeReferenceConflict() {
-    testJava("Foo { Bar foo(); Baz foo(); }", "Conflict: Bar#L1C7, Baz#L1C18");
-  }
-
-  @Test
   void testJavaTypeReferenceMethodConflict() {
     testJava("Foo { Bar foo()*; }", "Conflict: Bar#L1C7, foo()#L1C11");
-  }
-
-  @Test
-  void testJavaMethodConflict() {
-    testJava("Foo<T,S> { Bar foo(T t) | foo(S s); }", "Conflict: foo(S s)#L1C27, foo(T t)#L1C16");
   }
 
   private void testJava(String text, String message) {

--- a/src/test/java/validator/Utility.java
+++ b/src/test/java/validator/Utility.java
@@ -6,13 +6,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
 import org.antlr.v4.runtime.RecognitionException;
+import silverchain.Validator;
 import silverchain.diagram.Diagram;
 import silverchain.diagram.Diagrams;
 import silverchain.parser.AgParser;
 import silverchain.parser.Grammar;
 import silverchain.parser.Input;
 import silverchain.parser.adapter.Parser;
-import silverchain.validator.Validator;
 
 final class Utility {
 


### PR DESCRIPTION
Remove validations `checkTypeReferenceConflict` and `checkMethodConflict` because
- they can be found when compiling generated Java source code.
- the error messages reported by the Java compiler would be easier to understand the problems (compared to reading the messages reported by Silverchain)
- (it doesn't pay to implement the equivalence checking of Java types in Silverchain.)

The validation `checkTypeReferenceMethodConflict` is kept because this conflict cannot be found by the Java compiler; The generated code passes the compilation, but the API is not as specified in a AG file.