### PR TITLE
Improve tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'com.github.javaparser:javaparser-symbol-solver-core:3.23.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
+    testImplementation 'org.assertj:assertj-core:3.21.0'
 }
 
 generateGrammarSource {

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'com.github.javaparser:javaparser-symbol-solver-core:3.23.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
     testImplementation 'org.assertj:assertj-core:3.21.0'
 }
 

--- a/src/test/java/command/Result.java
+++ b/src/test/java/command/Result.java
@@ -1,6 +1,6 @@
 package command;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 final class Result {
 
@@ -17,18 +17,18 @@ final class Result {
   }
 
   void status(int i) {
-    assertEquals(i, status);
+    assertThat(status).isEqualTo(i);
   }
 
   void stdout(String s) {
-    assertEquals(s, stdout);
+    assertThat(stdout).isEqualTo(s);
   }
 
   void stderr(String s) {
-    assertEquals(s, stderr);
+    assertThat(stderr).isEqualTo(s);
   }
 
   void stderr1(String s) {
-    assertEquals(s, stderr.split("\n")[0]);
+    assertThat(stderr.split("\n")[0]).isEqualTo(s);
   }
 }

--- a/src/test/java/diagram/DiagramTester.java
+++ b/src/test/java/diagram/DiagramTester.java
@@ -1,5 +1,7 @@
 package diagram;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import silverchain.diagram.Diagram;
 import silverchain.diagram.State;
 import silverchain.diagram.Transition;
@@ -12,89 +14,89 @@ final class DiagramTester {
     this.diagram = diagram;
 
     for (State state : diagram.states()) {
-      assert state.diagram() == diagram;
+      assertThat(state.diagram()).isSameAs(diagram);
     }
 
     for (int i = 0; i < diagram.states().size(); i++) {
-      assert state(i).isStart() == (i == 0);
+      assertThat(state(i).isStart()).isSameAs((i == 0));
     }
 
     for (State state : diagram.states()) {
       for (Transition transition : state.transitions()) {
-        assert transition.source() == state;
+        assertThat(transition.source()).isSameAs(state);
       }
     }
   }
 
   DiagramTester name(String text) {
-    assert diagram.name().toString().equals(text);
+    assertThat((Object) diagram.name()).hasToString(text);
     return this;
   }
 
   DiagramTester typeParameterCount(int n) {
-    assert diagram.typeParameters().size() == n;
+    assertThat(diagram.typeParameters().size()).isSameAs(n);
     return this;
   }
 
   DiagramTester typeParameter(int i, String text) {
-    assert diagram.typeParameters().get(i).toString().equals(text);
+    assertThat(diagram.typeParameters().get(i)).hasToString(text);
     return this;
   }
 
   DiagramTester stateCount(int n) {
-    assert diagram.states().size() == n;
+    assertThat(diagram.states().size()).isSameAs(n);
     return this;
   }
 
   DiagramTester end(int... is) {
     for (int i = 0; i < diagram.states().size(); i++) {
-      assert state(i).isEnd() == in(is, i);
+      assertThat(state(i).isEnd()).isSameAs(in(is, i));
     }
     return this;
   }
 
   DiagramTester stateTypeParameterCount(int i, int n) {
-    assert state(i).typeParameters().size() == n;
+    assertThat(state(i).typeParameters().size()).isSameAs(n);
     return this;
   }
 
   DiagramTester stateTypeParameter(int i, int j, String text) {
-    assert state(i).typeParameters().get(j).toString().equals(text);
+    assertThat(state(i).typeParameters().get(j)).hasToString(text);
     return this;
   }
 
   DiagramTester stateTypeReferenceCount(int i, int n) {
-    assert state(i).typeReferences().size() == n;
+    assertThat(state(i).typeReferences().size()).isSameAs(n);
     return this;
   }
 
   DiagramTester stateTypeReference(int i, int j, String text) {
-    assert state(i).typeReferences().get(j).typeReference().toString().equals(text);
+    assertThat(state(i).typeReferences().get(j).typeReference()).hasToString(text);
     return this;
   }
 
   DiagramTester transitionCount(int i, int n) {
-    assert state(i).transitions().size() == n;
+    assertThat(state(i).transitions().size()).isSameAs(n);
     return this;
   }
 
   DiagramTester transitionDestination(int i, int j, int k) {
-    assert state(i).transitions().get(j).destination() == state(k);
+    assertThat(state(i).transitions().get(j).destination()).isSameAs(state(k));
     return this;
   }
 
   DiagramTester transitionTypeParameterCount(int i, int j, int n) {
-    assert state(i).transitions().get(j).typeParameters().size() == n;
+    assertThat(state(i).transitions().get(j).typeParameters().size()).isSameAs(n);
     return this;
   }
 
   DiagramTester transitionTypeParameter(int i, int j, int k, String text) {
-    assert state(i).transitions().get(j).typeParameters().get(k).toString().equals(text);
+    assertThat(state(i).transitions().get(j).typeParameters().get(k)).hasToString(text);
     return this;
   }
 
   DiagramTester transitionLabelRangeCount(int i, int j, int n) {
-    assert state(i).transitions().get(j).label().ranges().size() == n;
+    assertThat(state(i).transitions().get(j).label().ranges().size()).isSameAs(n);
     return this;
   }
 

--- a/src/test/java/diagram/Tests.java
+++ b/src/test/java/diagram/Tests.java
@@ -1,5 +1,7 @@
 package diagram;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -275,7 +277,7 @@ final class Tests {
   void testForCoverage() {
     Diagram diagram = compile("Foo { void foo(); }");
     Label label = diagram.states().get(0).transitions().get(0).label();
-    assert !label.equals(diagram);
+    assertThat(label).isNotEqualTo(diagram);
   }
 
   private DiagramTester test(String text) {

--- a/src/test/java/generator/Tests.java
+++ b/src/test/java/generator/Tests.java
@@ -1,6 +1,7 @@
 package generator;
 
 import static generator.Utility.generateJava;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -60,9 +61,9 @@ final class Tests {
     String javadoc = "src/test/resources/java/src/main";
     List<File> generated = generateJava(Utility.read(path), javadoc);
     List<File> expected = expectedJavaFiles(name);
-    assert generated.size() == expected.size();
+    assertThat(generated.size()).isEqualTo(expected.size());
     for (File file : generated) {
-      assert expected.stream().anyMatch(f -> equals(f, file));
+      assertThat(expected).anyMatch(f -> equals(f, file));
     }
   }
 

--- a/src/test/java/generator/Tests.java
+++ b/src/test/java/generator/Tests.java
@@ -11,54 +11,27 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import silverchain.generator.File;
 
 final class Tests {
 
   private final Path resources = Paths.get("src").resolve("test").resolve("resources");
 
-  @Test
-  void testAlertDialog() {
-    test("alertdialog");
-  }
-
-  @Test
-  void testJavadocTest() {
-    test("javadoctest");
-  }
-
-  @Test
-  void testListUtil() {
-    test("listutil");
-  }
-
-  @Test
-  void testMapBuilder() {
-    test("mapbuilder");
-  }
-
-  @Test
-  void testMatrix() {
-    test("matrix");
-  }
-
-  @Test
-  void testMelody() {
-    test("melody");
-  }
-
-  @Test
-  void testTripletBuilder() {
-    test("tripletbuilder");
-  }
-
-  @Test
-  void testItemization() {
-    test("itemization");
-  }
-
-  private void test(String name) {
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "alertdialog",
+        "javadoctest",
+        "listutil",
+        "mapbuilder",
+        "matrix",
+        "melody",
+        "tripletbuilder",
+        "itemization"
+      })
+  void test(String name) {
     Path path = resources.resolve(name + ".ag");
     String javadoc = "src/test/resources/java/src/main";
     Map<Path, String> generated = toComparisonMap(generateJava(Utility.read(path), javadoc));

--- a/src/test/java/parser/Tests.java
+++ b/src/test/java/parser/Tests.java
@@ -1,7 +1,8 @@
 package parser;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -13,6 +14,8 @@ import org.junit.jupiter.api.Test;
 import silverchain.parser.ASTNode;
 import silverchain.parser.AgParser;
 import silverchain.parser.DuplicateDeclaration;
+import silverchain.parser.Location;
+import silverchain.parser.Range;
 import silverchain.parser.adapter.Parser;
 
 final class Tests {
@@ -29,8 +32,8 @@ final class Tests {
     test(AgParser::typeParameter, "T");
 
     ASTNode node = parse(AgParser::typeParameter, "T");
-    assert node.typeParameters().size() == 1;
-    assert node.typeParameters().get(0).name().equals("T");
+    assertThat(node.typeParameters().size()).isSameAs(1);
+    assertThat(node.typeParameters().get(0).name()).isEqualTo("T");
   }
 
   @Test
@@ -160,10 +163,10 @@ final class Tests {
     test(AgParser::classDeclaration, "Foo { Foo foo(); }");
 
     ASTNode node1 = parse(AgParser::classDeclaration, "Foo<T, T> {}");
-    assertThrows(DuplicateDeclaration.class, node1::validate);
+    assertThatThrownBy(node1::validate).isExactlyInstanceOf(DuplicateDeclaration.class);
 
     ASTNode node2 = parse(AgParser::classDeclaration, "Foo<T, S> {}");
-    assertDoesNotThrow(node2::validate);
+    assertThatCode(node2::validate).doesNotThrowAnyException();
   }
 
   @Test
@@ -173,17 +176,19 @@ final class Tests {
     ASTNode node3 = parse(AgParser::classDeclaration, "Baz<T> {}");
     ASTNode node4 = parse(AgParser::classDeclaration, "\nQux {}");
 
-    assert node1.range().hashCode() == node2.range().hashCode();
+    Range range1 = node1.range();
+    assertThat(range1)
+        .hasSameHashCodeAs(node2.range())
+        .isEqualTo(node2.range())
+        .isEqualByComparingTo(node2.range())
+        .isNotEqualTo(node3.range())
+        .isNotEqualTo(node4.range())
+        .isLessThan(node3.range())
+        .isLessThan(node4.range());
 
-    assert node1.range().equals(node2.range());
-    assert !node1.range().equals(node3.range());
-    assert !node1.range().equals(node4.range());
+    assertThat(node3.range()).isGreaterThan(range1);
 
-    assert node1.range().compareTo(node2.range()) == 0;
-    assert node1.range().compareTo(node3.range()) < 0;
-    assert node3.range().compareTo(node1.range()) > 0;
-    assert node1.range().compareTo(node4.range()) < 0;
-    assert node4.range().compareTo(node1.range()) > 0;
+    assertThat(node4.range()).isGreaterThan(range1);
   }
 
   @Test
@@ -192,22 +197,19 @@ final class Tests {
     ASTNode node1 = parse(AgParser::classDeclaration, "Foo {}");
     ASTNode node2 = parse(AgParser::classDeclaration, "Bar {}");
 
-    assert node1.hashCode() != node2.hashCode();
-    assert !node1.equals(node2);
-    assert node1.compareTo(node2) > 0;
+    assertThat(node1)
+        .isNotNull()
+        .doesNotHaveSameHashCodeAs(node2)
+        .isNotEqualTo(node2)
+        .isGreaterThan(node2)
+        .isEqualTo(node1)
+        .isNotEqualTo(node1.range());
 
-    assert node1.equals(node1);
-    assert !node1.equals(null);
-    assert !node1.equals(node1.range());
+    Range range1 = node1.range();
+    assertThat(range1).isNotNull().isEqualTo(range1).isNotEqualTo(node1).hasToString("L1C1-L1C6");
 
-    assert node1.range().equals(node1.range());
-    assert !node1.range().equals(null);
-    assert !node1.range().equals(node1);
-    assert node1.range().toString().equals("L1C1-L1C6");
-
-    assert node1.range().begin().equals(node1.range().begin());
-    assert !node1.range().begin().equals(null);
-    assert !node1.range().begin().equals(node1);
+    Location begin1 = range1.begin();
+    assertThat(begin1).isNotNull().isEqualTo(begin1).isNotEqualTo(node1);
   }
 
   private void test(Function<AgParser, ParseTree> selector, String text) {
@@ -216,12 +218,13 @@ final class Tests {
 
   private void test(Function<AgParser, ParseTree> selector, String text, String expected) {
     ASTNode result = parse(selector, text);
-    assert result.toString().equals(expected);
-    assert result.range().begin().line() == result.range().end().line();
-    assert result.range().end().column() - result.range().begin().column() + 1 == text.length();
+    assertThat(result).hasToString(expected);
+    assertThat(result.range().begin().line()).isSameAs(result.range().end().line());
+    assertThat(result.range().end().column() - result.range().begin().column() + 1)
+        .isSameAs(text.length());
   }
 
-  protected ASTNode parse(Function<AgParser, ParseTree> selector, String text) {
+  private ASTNode parse(Function<AgParser, ParseTree> selector, String text) {
     InputStream stream = new ByteArrayInputStream(text.getBytes());
     Parser parser = new Parser(stream);
     try {

--- a/src/test/java/validator/Tests.java
+++ b/src/test/java/validator/Tests.java
@@ -1,6 +1,9 @@
 package validator;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
@@ -9,20 +12,19 @@ import silverchain.ValidationError;
 final class Tests {
 
   @Test
-  void testJavaTypeReferenceMethodConflict() {
+  void testJavaTypeReferenceMethodConflict() throws IOException {
     testJava("Foo { Bar foo()*; }", "Conflict: Bar#L1C7, foo()#L1C11");
   }
 
-  private void testJava(String text, String message) {
+  private void testJava(String text, String message) throws IOException {
     test(Utility::validateJava, text, message);
   }
 
-  private void test(Consumer<InputStream> f, String text, String message) {
-    try {
-      f.accept(new ByteArrayInputStream(text.getBytes()));
-      assert false;
-    } catch (ValidationError e) {
-      assert e.getMessage().equals(message);
+  private void test(Consumer<InputStream> f, String text, String message) throws IOException {
+    try (ByteArrayInputStream stream = new ByteArrayInputStream(text.getBytes())) {
+      assertThatThrownBy(() -> f.accept(stream))
+          .isExactlyInstanceOf(ValidationError.class)
+          .hasMessage(message);
     }
   }
 }

--- a/src/test/resources/java/build.gradle
+++ b/src/test/resources/java/build.gradle
@@ -13,6 +13,8 @@ repositories {
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
+    testImplementation 'org.assertj:assertj-core:3.21.0'
 }
 
 test {

--- a/src/test/resources/java/src/test/java/ItemizationTest.java
+++ b/src/test/resources/java/src/test/java/ItemizationTest.java
@@ -1,3 +1,5 @@
+import static org.assertj.core.api.Assertions.assertThat;
+
 import itemization.Itemization;
 import org.junit.jupiter.api.Test;
 
@@ -17,8 +19,7 @@ final class ItemizationTest {
             .end()
             .toTeX();
 
-    assert s.equals(
-        "\\begin{itemize}\n"
+    assertThat(s).isEqualTo("\\begin{itemize}\n"
             + "\\item foo\n"
             + "\\begin{itemize}\n"
             + "\\item 1\n"

--- a/src/test/resources/java/src/test/java/ListUtilTest.java
+++ b/src/test/resources/java/src/test/java/ListUtilTest.java
@@ -1,4 +1,6 @@
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Stream.of;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -10,17 +12,17 @@ final class ListUtilTest {
 
   @Test
   void testCopy1() {
-    List<Integer> ls1 = Stream.of(1, 2, 3).collect(toList());
+    List<Integer> ls1 = of(1, 2, 3).collect(toList());
     List<Number> ls2 = new ArrayList<>();
     new ListUtil().copy().from(ls1).to(ls2);
-    assert ls1.equals(ls2);
+    assertThat(ls1).isEqualTo(ls2);
   }
 
   @Test
   void testCopy2() {
-    List<Integer> ls1 = Stream.of(1, 2, 3).collect(toList());
+    List<Integer> ls1 = of(1, 2, 3).collect(toList());
     List<Number> ls2 = new ArrayList<>();
     new ListUtil().copy(ls1, ls2);
-    assert ls1.equals(ls2);
+    assertThat(ls1).isEqualTo(ls2);
   }
 }

--- a/src/test/resources/java/src/test/java/MapBuilderTest.java
+++ b/src/test/resources/java/src/test/java/MapBuilderTest.java
@@ -1,3 +1,5 @@
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Map;
 import mapbuilder.MapBuilder;
 import org.junit.jupiter.api.Test;
@@ -7,13 +9,13 @@ final class MapBuilderTest {
   @Test
   void test1() {
     Map<String, String> map = new MapBuilder().put("foo", "bar").put("baz", "qux").build();
-    assert map.get("foo").equals("bar");
-    assert map.get("baz").equals("qux");
+    assertThat(map.get("foo")).isEqualTo("bar");
+    assertThat(map.get("baz")).isEqualTo("qux");
   }
 
   @Test
   void test2() {
     Map<Integer, Integer> map = new MapBuilder().build();
-    assert map.isEmpty();
+    assertThat(map).isEmpty();
   }
 }


### PR DESCRIPTION
Note: you may want to wait before merging this to `main`, see my chat message.

### 297d362 - Replace 'assert' keyword with proper assertions
- The `assert` language keyword has no effect unless the JVM was started in a special mode enabling those assertions (`-ea` command line argument).
  - The reason for this is that the keyword is not intended for unit tests, but for production code: the idea is that the developer puts asserts in the code base and enables assertions during development and (manual or automated) testing. Then, when an end user runs the software, `assert` is skipped and causes no performance drawback.
  - My personal impression is that for production code, the keyword is not in widespread use. And in 20+ years of Java development, I have never encountered unit tests that use it.
  - When creating a run configuration for tests, my IDE adds the `-ea` option by default and `gradle :test` seems to use that option, as well. So the assertions *are* usually executed, but I would not recommend relying on it - especially since there are better options (see below).
- There are several options for writing assertions for unit testing code that are not only independent of the `-ea` option, but also improve expressiveness and error messages.
  - One option is to simply use JUnit's `Assertions` class (which offers `assertEquals()`, `assertNotNull()` etc).
  - The other is combining that class with [Hamcrest matchers](http://hamcrest.org/JavaHamcrest/tutorial). So far, I have not seen this in production code, though, most likely because people stick with either the simpler option above or the more powerful option below.
  - The option I like most is [AssertJ](https://assertj.github.io/doc/), which offers several advantages over the aforementioned approaches. The most important one is that it's a fluent API that offers dozens of useful and chainable assertions based on the type of the variable to check.
    - Fun fact: there's even the possibility to hook [custom assertions for your own classes](https://assertj.github.io/doc/#assertj-core-custom-assertions) into this API, creating something very similar to what you already do with `DiagramTester`.

### b9a1cd7 - Add nice assertion failure messages for file content checks

When I manipulate `MapBuilder0Impl` so that the test fails (adding a `// ⚡` comment), the previous `assert` would throw this error, without revealing any details about the offending file:

```
java.lang.AssertionError at generator.Tests.test(Tests.java:65)
```

Obviously, we can do better.

However, error messages created by AssertJ's collection assertions do not work particularly well on instances of Silverchain's `File` class because its `toString()` doesn't include the file contents (and even then, listing all of the expected files and all the actual files would not be useful). 

So I wrote some custom code in the test that results in this error message (using `(...)` to shorten it for this quote here):

```
org.opentest4j.AssertionFailedError: [Contents of mapbuilder/MapBuilder0Impl.java]
expected: "package mapbuilder;

// ⚡
@SuppressWarnings({"rawtypes", "unchecked"})
class MapBuilder0Impl implements mapbuilder.intermediates.MapBuilder0 {
(...)
"
but was: "package mapbuilder;

@SuppressWarnings({"rawtypes", "unchecked"})
class MapBuilder0Impl implements mapbuilder.intermediates.MapBuilder0 {
(...)
"
at java.base@11.0.11/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
at java.base@11.0.11/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
at java.base@11.0.11/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
at app//generator.Tests.test(Tests.java:71)
(...)
```

IntelliJ IDEA even offers a side-by-side diff for such errors.

### 55be58a - Refactor tests to use @ParameterizedTest

Not much to say about this, the changes should be self-explanatory. Let me just stress that even though we now use the same method for several tests, each test run is still individually identifiable, so there's no drawback compared to the previous approach with all these near-identical test methods.
