### PR TITLE
Always run tests before publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,8 @@ check {
 
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
+tasks.withType(AbstractPublishToMaven) { it.dependsOn test }
+
 publishing {
     repositories {
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,7 @@ check {
 
 ext.isReleaseVersion = !version.endsWith("SNAPSHOT")
 
-tasks.withType(AbstractPublishToMaven) { it.dependsOn test }
+tasks.withType(AbstractPublishToMaven) { it.dependsOn check }
 
 publishing {
     repositories {


### PR DESCRIPTION
Note: you may want to wait before merging this to `main`, see my chat message.

I only now discovered that Gradle's `maven-publish` plugin does not run tests by default. This PR fixes that.